### PR TITLE
Little fix in Kernel.cc

### DIFF
--- a/src/Kernel.cc
+++ b/src/Kernel.cc
@@ -530,7 +530,7 @@ std::string getOsName()
 	#ifdef __i386__
 	bits = " x86";
 	#endif
-	#ifdef __x8_64__
+	#ifdef __x86_64__
 	bits = " x86_64";
 	#endif
 


### PR DESCRIPTION
In helper function getOsName() I've changed incorrect " #ifdef __x8_64__ " statement - to " #ifdef __x86_64__ " :)