### PR TITLE
Compact Makefile syntax

### DIFF
--- a/src/scf/Makefile
+++ b/src/scf/Makefile
@@ -9,14 +9,20 @@ CLEAN=rm -rf *.o *.a
 OBJ=rhf.o Diis.o
 HEADERS=
 
+.cc.o:
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+rhf.o: rhf.cc
+Diis.o: Diis.cc
+
 libscf.o: $(OBJ)
 	ld -r $(OBJ) -o libscf.o
 
-rhf.o: rhf.cc
-	$(CXX) $(CXXFLAGS) -c -o rhf.o rhf.cc
+#rhf.o: rhf.cc
+#	$(CXX) $(CXXFLAGS) -c -o rhf.o rhf.cc
 
-Diis.o: Diis.cc
-	$(CXX) $(CXXFLAGS) -c -o Diis.o Diis.cc
+#Diis.o: Diis.cc
+#	$(CXX) $(CXXFLAGS) -c -o Diis.o Diis.cc
 
 clean:
 	$(CLEAN)


### PR DESCRIPTION
When you have a lot of identical rules like compiling a number of .cc file to .o files you may create a pattern in form
```
.$(INPUT_FORMAT).$(OUTPUT_FORMAT)
          some actions

first_file.$(INPUT_FORMAT): first_dependency second_dependency ...
second_file.$(INPUT_FORMAT): first_dep second_dep ...

```
and use this Makefile usability.
The ```$<``` Makefile symbol is the name of first dependency and the ```$@``` Makefile symbol is the name of the target,
for example, ```$<``` is ```rhf.cc``` , ```$@``` is ```rhf.o``` .
I think it is more compact syntax and I've seen it many projects.
You may use this syntax for Makefiles in other directories similarly :)